### PR TITLE
Refactor out server logic so it can be used as a library (raw use)

### DIFF
--- a/cloudmock/cloud_mock.go
+++ b/cloudmock/cloud_mock.go
@@ -1,0 +1,69 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudmock
+
+import (
+	"log"
+	"net"
+
+	"github.com/googleinterns/cloud-operations-api-mock/server/metric"
+	"github.com/googleinterns/cloud-operations-api-mock/server/trace"
+
+	"google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
+	"google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/grpc"
+)
+
+func StartMockServer(address string) *grpc.Server {
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		log.Fatalf("mock server failed to listen: %v", err)
+	}
+
+	grpcServer := grpc.NewServer()
+	cloudtrace.RegisterTraceServiceServer(grpcServer, &trace.MockTraceServer{})
+	monitoring.RegisterMetricServiceServer(grpcServer, &metric.MockMetricServer{})
+
+	log.Printf("Listening on %s\n", address)
+
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			log.Fatalf("mock server failed to serve: %v", err)
+		}
+	}()
+
+	return grpcServer
+}
+
+func ShutdownMockServer(grpcServer *grpc.Server) {
+	grpcServer.GracefulStop()
+}
+
+func StartMockClients(address string) (*grpc.ClientConn, cloudtrace.TraceServiceClient, monitoring.MetricServiceClient) {
+	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("did not connect: %s", err)
+	}
+
+	traceClient := cloudtrace.NewTraceServiceClient(conn)
+	metricClient := monitoring.NewMetricServiceClient(conn)
+	return conn, traceClient, metricClient
+}
+
+func ShutdownMockClients(conn *grpc.ClientConn) {
+	if err := conn.Close(); err != nil {
+		log.Fatalf("failed to close connection: %s", err)
+	}
+}

--- a/cmd/mock_server.go
+++ b/cmd/mock_server.go
@@ -16,15 +16,8 @@ package main
 
 import (
 	"flag"
-	"log"
-	"net"
 
-	"google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
-	"google.golang.org/genproto/googleapis/monitoring/v3"
-	"google.golang.org/grpc"
-
-	"github.com/googleinterns/cloud-operations-api-mock/server/metric"
-	"github.com/googleinterns/cloud-operations-api-mock/server/trace"
+	"github.com/googleinterns/cloud-operations-api-mock/cloudmock"
 )
 
 const (
@@ -38,19 +31,5 @@ var (
 
 func main() {
 	flag.Parse()
-
-	lis, err := net.Listen("tcp", *address)
-	if err != nil {
-		log.Fatalf("mock server failed to listen: %v", err)
-	}
-
-	grpcServer := grpc.NewServer()
-	cloudtrace.RegisterTraceServiceServer(grpcServer, &trace.MockTraceServer{})
-	monitoring.RegisterMetricServiceServer(grpcServer, &metric.MockMetricServer{})
-
-	log.Printf("Listening on %s\n", *address)
-
-	if err := grpcServer.Serve(lis); err != nil {
-		log.Fatalf("mock server failed to serve: %v", err)
-	}
+	cloudmock.StartMockServer(*address)
 }


### PR DESCRIPTION
This change allows users to spin up the server/clients through a couple lines of code using the `cloudmock` package rather than having to manually spin up the server, similar to the [raw use of Moto](https://github.com/spulec/moto#raw-use).
Sample use in a unit test:

```
func TestXxx(t *testing.T) {
    mock := cloudmock.NewCloudMock()

    // Run tests here using mock.MockTraceClient and mock.MockMetricClient

    mock.Shutdown()
}
```