### PR TITLE
Store spans in memory and check for duplicate span names

### DIFF
--- a/cmd/mock_server.go
+++ b/cmd/mock_server.go
@@ -51,7 +51,7 @@ func startStandaloneServer() {
 	}
 
 	grpcServer := grpc.NewServer()
-	cloudtrace.RegisterTraceServiceServer(grpcServer, &trace.MockTraceServer{})
+	cloudtrace.RegisterTraceServiceServer(grpcServer, trace.NewMockTraceServer())
 	monitoring.RegisterMetricServiceServer(grpcServer, &metric.MockMetricServer{})
 
 	log.Printf("Listening on %s\n", lis.Addr().String())

--- a/server/trace/mock_trace_test.go
+++ b/server/trace/mock_trace_test.go
@@ -47,7 +47,7 @@ func setup() {
 	// Setup the in-memory server.
 	lis = bufconn.Listen(bufSize)
 	grpcServer = grpc.NewServer()
-	cloudtrace.RegisterTraceServiceServer(grpcServer, &MockTraceServer{})
+	cloudtrace.RegisterTraceServiceServer(grpcServer, NewMockTraceServer())
 	go func() {
 		if err := grpcServer.Serve(lis); err != nil {
 			log.Fatalf("server exited with error: %v", err)
@@ -150,8 +150,8 @@ func TestMockTraceServer_BatchWriteSpans_MissingField(t *testing.T) {
 	defer tearDown()
 
 	missingFieldsSpan := []*cloudtrace.Span{
-		generateMissingFieldSpan("test-span-1", "Name", "StartTime"),
-		generateMissingFieldSpan("test-span-2"),
+		generateMissingFieldSpan("test-span-4", "Name", "StartTime"),
+		generateMissingFieldSpan("test-span-5"),
 	}
 	in := &cloudtrace.BatchWriteSpansRequest{
 		Name:  "test-project",
@@ -208,7 +208,6 @@ func TestMockTraceServer_CreateSpan(t *testing.T) {
 
 	span := generateSpan("test-span-1")
 	in, want := span, span
-
 	responseSpan, err := client.CreateSpan(ctx, in)
 	if err != nil {
 		t.Fatalf("failed to call CreateSpan: %v", err)

--- a/server/trace/mock_trace_test.go
+++ b/server/trace/mock_trace_test.go
@@ -138,6 +138,7 @@ func TestMockTraceServer_BatchWriteSpans(t *testing.T) {
 	response, err := client.BatchWriteSpans(ctx, in)
 	if err != nil {
 		t.Fatalf("failed to call BatchWriteSpans: %v", err)
+		return
 	}
 
 	if !proto.Equal(response, want) {
@@ -167,6 +168,7 @@ func TestMockTraceServer_BatchWriteSpans_MissingField(t *testing.T) {
 	if err == nil {
 		t.Errorf("BatchWriteSpans(%v) == %v, expected error %v",
 			in, responseSpan, want)
+		return
 	}
 
 	if valid := validation.ValidateErrDetails(err, missingFields); !valid {
@@ -193,11 +195,12 @@ func TestMockTraceServer_BatchWriteSpans_InvalidTimestamp(t *testing.T) {
 	if err == nil {
 		t.Errorf("BatchWriteSpans(%v) == %v, expected error %v",
 			in, responseSpan, want)
-	} else {
-		if !strings.Contains(err.Error(), want.Error()) {
-			t.Errorf("BatchWriteSpans(%v) returned error %v, expected error %v",
-				in, err.Error(), want)
-		}
+		return
+	}
+
+	if !strings.Contains(err.Error(), want.Error()) {
+		t.Errorf("BatchWriteSpans(%v) returned error %v, expected error %v",
+			in, err.Error(), want)
 	}
 }
 
@@ -215,16 +218,13 @@ func TestMockTraceServer_BatchWriteSpans_DuplicateName(t *testing.T) {
 
 	responseSpan, err := client.BatchWriteSpans(ctx, in)
 	if err == nil {
-		t.Errorf("BatchWriteSpans(%q) == %q, expected error %q",
+		t.Errorf("BatchWriteSpans(%v) == %v, expected error %v",
 			in, responseSpan, want.Err())
-	} else {
-		if !strings.Contains(err.Error(), want.Err().Error()) {
-			t.Errorf("BatchWriteSpans(%q) returned error %q, expected error %q",
-				in, err.Error(), want.Err())
-		}
-		if valid := validation.ValidateDuplicateSpanNames(err, duplicateSpanName); !valid {
-			t.Errorf("expected duplicate spanName: %q", duplicateSpanName)
-		}
+		return
+	}
+
+	if valid := validation.ValidateDuplicateSpanNames(err, duplicateSpanName); !valid {
+		t.Errorf("expected duplicate spanName: %v", duplicateSpanName)
 	}
 }
 
@@ -238,6 +238,7 @@ func TestMockTraceServer_CreateSpan(t *testing.T) {
 	responseSpan, err := client.CreateSpan(ctx, in)
 	if err != nil {
 		t.Fatalf("failed to call CreateSpan: %v", err)
+		return
 	}
 
 	if !proto.Equal(responseSpan, want) {
@@ -261,6 +262,7 @@ func TestMockTraceServer_CreateSpan_MissingFields(t *testing.T) {
 	if err == nil {
 		t.Errorf("CreateSpan(%v) == %v, expected error %v",
 			in, responseSpan, want)
+		return
 	}
 
 	if valid := validation.ValidateErrDetails(err, missingFields); !valid {
@@ -279,10 +281,11 @@ func TestMockTraceServer_CreateSpan_InvalidTimestamp(t *testing.T) {
 	if err == nil {
 		t.Errorf("CreateSpan(%v) == %v, expected error %v",
 			in, responseSpan, want)
-	} else {
-		if !strings.Contains(err.Error(), want.Error()) {
-			t.Errorf("CreateSpan(%v) returned error %v, expected error %v",
-				in, err.Error(), want)
-		}
+		return
+	}
+
+	if !strings.Contains(err.Error(), want.Error()) {
+		t.Errorf("CreateSpan(%v) returned error %v, expected error %v",
+			in, err.Error(), want)
 	}
 }

--- a/validation/mock_trace_validation.go
+++ b/validation/mock_trace_validation.go
@@ -15,30 +15,39 @@
 package validation
 
 import (
+	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/golang/protobuf/ptypes"
 
 	"google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+)
+
+const (
+	duplicateSpanNameMsg = "duplicate span name: %v"
 )
 
 var (
 	ErrInvalidTimestamp   = status.Error(codes.InvalidArgument, "start time must be before end time")
 	ErrMalformedTimestamp = status.Error(codes.InvalidArgument, "unable to parse timestamp")
+	ErrDuplicateSpanName  = status.New(codes.AlreadyExists, "duplicate span name")
 	requiredFields        = []string{"Name", "SpanId", "DisplayName", "StartTime", "EndTime"}
 )
 
-func IsSpanValid(span *cloudtrace.Span, requestName string) error {
-	if err := CheckForRequiredFields(requiredFields, reflect.ValueOf(span), requestName); err != nil {
-		return err
-	}
+func ValidateSpans(requestName string, spans ...*cloudtrace.Span) error {
+	for _, span := range spans {
+		if err := CheckForRequiredFields(requiredFields, reflect.ValueOf(span), requestName); err != nil {
+			return err
+		}
 
-	if err := validateTimeStamps(span); err != nil {
-		return err
+		if err := validateTimeStamps(span); err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
 
@@ -54,6 +63,25 @@ func validateTimeStamps(span *cloudtrace.Span) error {
 
 	if !start.Before(end) {
 		return ErrInvalidTimestamp
+	}
+	return nil
+}
+
+func AddSpans(uploadedSpans map[string]*cloudtrace.Span, lock *sync.Mutex, spans ...*cloudtrace.Span) error {
+	br := &errdetails.ErrorInfo{}
+
+	lock.Lock()
+	defer lock.Unlock()
+	for _, span := range spans {
+		if _, ok := uploadedSpans[span.Name]; ok {
+			br.Reason = fmt.Sprintf(duplicateSpanNameMsg, span.Name)
+			st, err := ErrDuplicateSpanName.WithDetails(br)
+			if err != nil {
+				panic(fmt.Sprintf("unexpected error attaching metadata: %v", err))
+			}
+			return st.Err()
+		}
+		uploadedSpans[span.Name] = span
 	}
 	return nil
 }


### PR DESCRIPTION
As per [this comment from the proto](https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudtrace/v2/tracing.proto#L76), we cannot create spans with duplicate names. To make this check, we need to store the spans we receive in memory. This PR implements this by using a map of `{spanName: span}` in order to check for duplicates and also allow retrieval of spans by name in O(1) time .

This will also bridge into future PRs where we provide some additional custom RPCs for testing purposes, where we allow users to retrieve the data that they've exported (for example, retrieving how many spans have been created, etc.)