### PR TITLE
Switch to using constructor in cloud mock

### DIFF
--- a/cloudmock/cloud_mock.go
+++ b/cloudmock/cloud_mock.go
@@ -42,7 +42,7 @@ func startMockServer() (string, *grpc.Server) {
 	}
 
 	grpcServer := grpc.NewServer()
-	cloudtrace.RegisterTraceServiceServer(grpcServer, &trace.MockTraceServer{})
+	cloudtrace.RegisterTraceServiceServer(grpcServer, trace.NewMockTraceServer())
 	monitoring.RegisterMetricServiceServer(grpcServer, &metric.MockMetricServer{})
 
 	log.Printf("Listening on %s\n", lis.Addr().String())


### PR DESCRIPTION
Missed changing this when I originally switched the mock trace server to using a constructor 