### PR TITLE
Add additional validations for spans

### DIFF
--- a/internal/validation/mock_trace_validation.go
+++ b/internal/validation/mock_trace_validation.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sync"
 	"time"
 
@@ -29,20 +30,83 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var (
-	ErrInvalidTimestamp   = status.Error(codes.InvalidArgument, "start time must be before end time")
-	ErrMalformedTimestamp = status.Error(codes.InvalidArgument, "unable to parse timestamp")
-	ErrDuplicateSpanName  = status.New(codes.AlreadyExists, "duplicate span name")
-	requiredFields        = []string{"Name", "SpanId", "DisplayName", "StartTime", "EndTime"}
+const (
+	maxAnnotationAttributes = 4
+	maxAnnotationBytes      = 256
+	maxAttributes           = 32
+	maxAttributeKeyBytes    = 128
+	maxAttributeValueBytes  = 256
+	maxDisplayNameBytes     = 128
+	maxLinks                = 128
+	maxTimeEvents           = 32
 )
 
+var (
+	requiredFields   = []string{"Name", "SpanId", "DisplayName", "StartTime", "EndTime"}
+	spanNameRegex    = regexp.MustCompile("^projects/(.*)/traces/[a-fA-F0-9]{32}/spans/[a-fA-F0-9]{16}")
+	projectNameRegex = regexp.MustCompile("^projects/(.*)")
+
+	StatusInvalidSpanName = status.Error(codes.InvalidArgument,
+		"span name must be of the form projects/{project_id}/traces/{trace_id}/spans/{span_id}")
+	StatusInvalidProjectName = status.Error(codes.InvalidArgument,
+		"project name must be of the form projects/{project_id}")
+	StatusInvalidTimestamp = status.Error(codes.InvalidArgument,
+		"start time must be before end time")
+	StatusMalformedTimestamp = status.Error(codes.InvalidArgument,
+		"unable to parse timestamp")
+	StatusTimeEventMissingTime = status.Error(codes.InvalidArgument,
+		"time events' time field cannot be empty")
+	StatusInvalidMessageEvent = status.Error(codes.InvalidArgument,
+		"message events must contain a type, ID and uncompressed size in bytes")
+	StatusInvalidLink = status.Error(codes.InvalidArgument,
+		"links must contain a Span ID and trace ID")
+
+	StatusInvalidDisplayName = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("displayName has max length of %v bytes", maxDisplayNameBytes))
+	StatusTooManyAttributes = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("a span can have at most %v attributes", maxAttributes))
+	StatusInvalidAttributeKey = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("attribute keys have a max length of %v bytes", maxAttributeKeyBytes))
+	StatusInvalidAttributeValue = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("attribute values have a max length of %v bytes", maxAttributeValueBytes))
+	StatusTooManyTimeEvents = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("a span can have at most %v time events", maxTimeEvents))
+	StatusInvalidAnnotation = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("annotation descriptions have a max length of %v bytes", maxAnnotationBytes))
+	StatusTooManyAnnotationAttributes = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("annotations can have at most %v attributes", maxAnnotationAttributes))
+	StatusTooManyLinks = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("a span can have at most %v links", maxLinks))
+
+	StatusDuplicateSpanName = status.New(codes.AlreadyExists, "duplicate span name")
+)
+
+// ValidateSpans checks that the spans conform to the API requirements.
+// That is, required fields are present, and optional fields are of the correct form.
 func ValidateSpans(requestName string, spans ...*cloudtrace.Span) error {
 	for _, span := range spans {
+		// Validate required fields are present and semantically make sense.
 		if err := CheckForRequiredFields(requiredFields, reflect.ValueOf(span), requestName); err != nil {
 			return err
 		}
-
+		if err := validateName(span.Name); err != nil {
+			return err
+		}
 		if err := validateTimeStamps(span); err != nil {
+			return err
+		}
+		if err := validateDisplayName(span.DisplayName); err != nil {
+			return err
+		}
+
+		// Validate that if optional fields are present, they conform to the API.
+		if err := validateAttributes(span.Attributes, maxAttributes); err != nil {
+			return err
+		}
+		if err := validateTimeEvents(span.TimeEvents); err != nil {
+			return err
+		}
+		if err := validateLinks(span.Links); err != nil {
 			return err
 		}
 	}
@@ -52,19 +116,21 @@ func ValidateSpans(requestName string, spans ...*cloudtrace.Span) error {
 func validateTimeStamps(span *cloudtrace.Span) error {
 	start, err := ptypes.Timestamp(span.StartTime)
 	if err != nil {
-		return ErrMalformedTimestamp
+		return StatusMalformedTimestamp
 	}
 	end, err := ptypes.Timestamp(span.EndTime)
 	if err != nil {
-		return ErrMalformedTimestamp
+		return StatusMalformedTimestamp
 	}
 
 	if !start.Before(end) {
-		return ErrInvalidTimestamp
+		return StatusInvalidTimestamp
 	}
 	return nil
 }
 
+// AddSpans adds the given spans to the map of uploaded spans as long as there are no duplicate names.
+// If a duplicate span name is detected, it will not be written, and an error is returned.
 func AddSpans(uploadedSpans map[string]*cloudtrace.Span, lock *sync.Mutex,
 	delay time.Duration, ctx context.Context, spans ...*cloudtrace.Span) error {
 
@@ -79,7 +145,7 @@ func AddSpans(uploadedSpans map[string]*cloudtrace.Span, lock *sync.Mutex,
 		for _, span := range spans {
 			if _, ok := uploadedSpans[span.Name]; ok {
 				br.Reason = span.Name
-				st, err := ErrDuplicateSpanName.WithDetails(br)
+				st, err := StatusDuplicateSpanName.WithDetails(br)
 				if err != nil {
 					panic(fmt.Sprintf("unexpected error attaching metadata: %v", err))
 				}
@@ -92,6 +158,117 @@ func AddSpans(uploadedSpans map[string]*cloudtrace.Span, lock *sync.Mutex,
 	return nil
 }
 
+// ValidateProjectName verifies that the project name from the BatchWriteSpans request
+// is of the form projects/[PROJECT_ID]
+func ValidateProjectName(projectName string) error {
+	if !projectNameRegex.MatchString(projectName) {
+		return StatusInvalidProjectName
+	}
+	return nil
+}
+
+// A display name can be at most 128 bytes.
+func validateDisplayName(displayName *cloudtrace.TruncatableString) error {
+	if len(displayName.Value) > maxDisplayNameBytes {
+		return StatusInvalidDisplayName
+	}
+	return nil
+}
+
+// The span name must be of the form projects/{project_id}/traces/{trace_id}/spans/{span_id} where
+// trace_id is a 32-char hex encoding, span_id is a 16-char hex encoding.
+func validateName(name string) error {
+	if !spanNameRegex.MatchString(name) {
+		return StatusInvalidSpanName
+	}
+	return nil
+}
+
+// A span can have at most 32 attributes, where each attribute is a dictionary.
+// The key is a string with max length of 128 bytes, and the value can be a string, int64 or bool.
+// If the value is a string, it has a max length of 256 bytes.
+func validateAttributes(attributes *cloudtrace.Span_Attributes, maxAttributes int) error {
+	if attributes == nil {
+		return nil
+	}
+	if len(attributes.AttributeMap) > maxAttributes {
+		return StatusTooManyAttributes
+	}
+
+	for k, v := range attributes.AttributeMap {
+		if len(k) > maxAttributeKeyBytes {
+			return StatusInvalidAttributeKey
+		}
+		if val, ok := v.Value.(*cloudtrace.AttributeValue_StringValue); ok {
+			if len(val.StringValue.Value) > maxAttributeValueBytes {
+				return StatusInvalidAttributeValue
+			}
+		}
+	}
+
+	return nil
+}
+
+// A span can have at most 32 TimeEvents. A TimeEvent consists of a TimeStamp,
+// and either an Annotation or a MessageEvent.
+// An Annotation is a dictionary that maps a string description to a list of attributes.
+// A MessageEvent describes messages sent between spans and must contain an ID and size.
+func validateTimeEvents(events *cloudtrace.Span_TimeEvents) error {
+	if events == nil {
+		return nil
+	}
+	if len(events.TimeEvent) > maxTimeEvents {
+		return StatusTooManyTimeEvents
+	}
+
+	for _, event := range events.TimeEvent {
+		if event.Time == nil {
+			return StatusTimeEventMissingTime
+		}
+
+		switch e := event.Value.(type) {
+		case *cloudtrace.Span_TimeEvent_Annotation_:
+			if len(e.Annotation.Description.Value) > maxAnnotationBytes {
+				return StatusInvalidAnnotation
+			}
+
+			if err := validateAttributes(e.Annotation.Attributes, maxAnnotationAttributes); err != nil {
+				return StatusTooManyAnnotationAttributes
+			}
+		case *cloudtrace.Span_TimeEvent_MessageEvent_:
+			if e.MessageEvent.Id <= 0 || e.MessageEvent.UncompressedSizeBytes <= 0 {
+				return StatusInvalidMessageEvent
+			}
+		}
+	}
+
+	return nil
+}
+
+// A span can have at most 128 links, which links the span to another span.
+// A link contains a traceId, spanId, the type of the span, and at most 32 attributes.
+func validateLinks(links *cloudtrace.Span_Links) error {
+	if links == nil {
+		return nil
+	}
+	if len(links.Link) > maxLinks {
+		return StatusTooManyLinks
+	}
+
+	for _, link := range links.Link {
+		if link.SpanId == "" || link.TraceId == "" {
+			return StatusInvalidLink
+		}
+		if err := validateAttributes(link.Attributes, maxAttributes); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ValidateDuplicateSpanNames is used in tests to verify that the error returned
+// contains the correct span name (that is, the duplicate span name).
 func ValidateDuplicateSpanNames(err error, duplicateName string) bool {
 	st := status.Convert(err)
 	for _, detail := range st.Details() {

--- a/internal/validation/mock_trace_validation.go
+++ b/internal/validation/mock_trace_validation.go
@@ -26,7 +26,6 @@ import (
 
 	"google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -45,40 +44,6 @@ var (
 	requiredFields   = []string{"Name", "SpanId", "DisplayName", "StartTime", "EndTime"}
 	spanNameRegex    = regexp.MustCompile("^projects/(.*)/traces/[a-fA-F0-9]{32}/spans/[a-fA-F0-9]{16}")
 	projectNameRegex = regexp.MustCompile("^projects/(.*)")
-
-	StatusInvalidSpanName = status.Error(codes.InvalidArgument,
-		"span name must be of the form projects/{project_id}/traces/{trace_id}/spans/{span_id}")
-	StatusInvalidProjectName = status.Error(codes.InvalidArgument,
-		"project name must be of the form projects/{project_id}")
-	StatusInvalidTimestamp = status.Error(codes.InvalidArgument,
-		"start time must be before end time")
-	StatusMalformedTimestamp = status.Error(codes.InvalidArgument,
-		"unable to parse timestamp")
-	StatusTimeEventMissingTime = status.Error(codes.InvalidArgument,
-		"time events' time field cannot be empty")
-	StatusInvalidMessageEvent = status.Error(codes.InvalidArgument,
-		"message events must contain a type, ID and uncompressed size in bytes")
-	StatusInvalidLink = status.Error(codes.InvalidArgument,
-		"links must contain a Span ID and trace ID")
-
-	StatusInvalidDisplayName = status.Error(codes.InvalidArgument,
-		fmt.Sprintf("displayName has max length of %v bytes", maxDisplayNameBytes))
-	StatusTooManyAttributes = status.Error(codes.InvalidArgument,
-		fmt.Sprintf("a span can have at most %v attributes", maxAttributes))
-	StatusInvalidAttributeKey = status.Error(codes.InvalidArgument,
-		fmt.Sprintf("attribute keys have a max length of %v bytes", maxAttributeKeyBytes))
-	StatusInvalidAttributeValue = status.Error(codes.InvalidArgument,
-		fmt.Sprintf("attribute values have a max length of %v bytes", maxAttributeValueBytes))
-	StatusTooManyTimeEvents = status.Error(codes.InvalidArgument,
-		fmt.Sprintf("a span can have at most %v time events", maxTimeEvents))
-	StatusInvalidAnnotation = status.Error(codes.InvalidArgument,
-		fmt.Sprintf("annotation descriptions have a max length of %v bytes", maxAnnotationBytes))
-	StatusTooManyAnnotationAttributes = status.Error(codes.InvalidArgument,
-		fmt.Sprintf("annotations can have at most %v attributes", maxAnnotationAttributes))
-	StatusTooManyLinks = status.Error(codes.InvalidArgument,
-		fmt.Sprintf("a span can have at most %v links", maxLinks))
-
-	StatusDuplicateSpanName = status.New(codes.AlreadyExists, "duplicate span name")
 )
 
 // ValidateSpans checks that the spans conform to the API requirements.

--- a/internal/validation/statuses.go
+++ b/internal/validation/statuses.go
@@ -23,35 +23,33 @@ import (
 
 var (
 	// Trace statuses.
-	StatusInvalidSpanName = status.Error(codes.InvalidArgument,
+	statusInvalidSpanName = status.Error(codes.InvalidArgument,
 		"span name must be of the form projects/{project_id}/traces/{trace_id}/spans/{span_id}")
-	StatusInvalidProjectName = status.Error(codes.InvalidArgument,
+	statusInvalidProjectName = status.Error(codes.InvalidArgument,
 		"project name must be of the form projects/{project_id}")
-	StatusInvalidTimestamp = status.Error(codes.InvalidArgument,
+	statusInvalidTimestamp = status.Error(codes.InvalidArgument,
 		"start time must be before end time")
-	StatusMalformedTimestamp = status.Error(codes.InvalidArgument,
+	statusMalformedTimestamp = status.Error(codes.InvalidArgument,
 		"unable to parse timestamp")
-	StatusTimeEventMissingTime = status.Error(codes.InvalidArgument,
+	statusTimeEventMissingTime = status.Error(codes.InvalidArgument,
 		"time events' time field cannot be empty")
-	StatusInvalidMessageEvent = status.Error(codes.InvalidArgument,
+	statusInvalidMessageEvent = status.Error(codes.InvalidArgument,
 		"message events must contain a type, ID and uncompressed size in bytes")
-	StatusInvalidLink = status.Error(codes.InvalidArgument,
+	statusInvalidLink = status.Error(codes.InvalidArgument,
 		"links must contain a Span ID and trace ID")
-	StatusInvalidDisplayName = status.Error(codes.InvalidArgument,
+	statusInvalidDisplayName = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("displayName has max length of %v bytes", maxDisplayNameBytes))
-	StatusTooManyAttributes = status.Error(codes.InvalidArgument,
+	statusTooManyAttributes = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("a span can have at most %v attributes", maxAttributes))
-	StatusInvalidAttributeKey = status.Error(codes.InvalidArgument,
+	statusInvalidAttributeKey = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("attribute keys have a max length of %v bytes", maxAttributeKeyBytes))
-	StatusInvalidAttributeValue = status.Error(codes.InvalidArgument,
+	statusInvalidAttributeValue = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("attribute values have a max length of %v bytes", maxAttributeValueBytes))
-	StatusTooManyTimeEvents = status.Error(codes.InvalidArgument,
+	statusTooManyTimeEvents = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("a span can have at most %v time events", maxTimeEvents))
-	StatusInvalidAnnotation = status.Error(codes.InvalidArgument,
+	statusInvalidAnnotation = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("annotation descriptions have a max length of %v bytes", maxAnnotationBytes))
-	StatusTooManyAnnotationAttributes = status.Error(codes.InvalidArgument,
-		fmt.Sprintf("annotations can have at most %v attributes", maxAnnotationAttributes))
-	StatusTooManyLinks = status.Error(codes.InvalidArgument,
+	statusTooManyLinks = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("a span can have at most %v links", maxLinks))
-	StatusDuplicateSpanName = status.New(codes.AlreadyExists, "duplicate span name")
+	statusDuplicateSpanName = status.New(codes.AlreadyExists, "duplicate span name")
 )

--- a/internal/validation/statuses.go
+++ b/internal/validation/statuses.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	// Trace statuses.
+	StatusInvalidSpanName = status.Error(codes.InvalidArgument,
+		"span name must be of the form projects/{project_id}/traces/{trace_id}/spans/{span_id}")
+	StatusInvalidProjectName = status.Error(codes.InvalidArgument,
+		"project name must be of the form projects/{project_id}")
+	StatusInvalidTimestamp = status.Error(codes.InvalidArgument,
+		"start time must be before end time")
+	StatusMalformedTimestamp = status.Error(codes.InvalidArgument,
+		"unable to parse timestamp")
+	StatusTimeEventMissingTime = status.Error(codes.InvalidArgument,
+		"time events' time field cannot be empty")
+	StatusInvalidMessageEvent = status.Error(codes.InvalidArgument,
+		"message events must contain a type, ID and uncompressed size in bytes")
+	StatusInvalidLink = status.Error(codes.InvalidArgument,
+		"links must contain a Span ID and trace ID")
+	StatusInvalidDisplayName = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("displayName has max length of %v bytes", maxDisplayNameBytes))
+	StatusTooManyAttributes = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("a span can have at most %v attributes", maxAttributes))
+	StatusInvalidAttributeKey = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("attribute keys have a max length of %v bytes", maxAttributeKeyBytes))
+	StatusInvalidAttributeValue = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("attribute values have a max length of %v bytes", maxAttributeValueBytes))
+	StatusTooManyTimeEvents = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("a span can have at most %v time events", maxTimeEvents))
+	StatusInvalidAnnotation = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("annotation descriptions have a max length of %v bytes", maxAnnotationBytes))
+	StatusTooManyAnnotationAttributes = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("annotations can have at most %v attributes", maxAnnotationAttributes))
+	StatusTooManyLinks = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("a span can have at most %v links", maxLinks))
+	StatusDuplicateSpanName = status.New(codes.AlreadyExists, "duplicate span name")
+)

--- a/server/trace/mock_trace.go
+++ b/server/trace/mock_trace.go
@@ -46,6 +46,9 @@ func NewMockTraceServer() *MockTraceServer {
 
 // BatchWriteSpans creates and stores a list of spans on the server.
 func (s *MockTraceServer) BatchWriteSpans(ctx context.Context, req *cloudtrace.BatchWriteSpansRequest) (*empty.Empty, error) {
+	if err := validation.ValidateProjectName(req.Name); err != nil {
+		return nil, err
+	}
 	if err := validation.ValidateSpans("BatchWriteSpans", req.Spans...); err != nil {
 		return nil, err
 	}

--- a/server/trace/mock_trace.go
+++ b/server/trace/mock_trace.go
@@ -52,7 +52,7 @@ func (s *MockTraceServer) BatchWriteSpans(ctx context.Context, req *cloudtrace.B
 	if err := validation.ValidateSpans("BatchWriteSpans", req.Spans...); err != nil {
 		return nil, err
 	}
-	if err := validation.AddSpans(s.uploadedSpans, &s.uploadedSpansLock, s.delay, ctx, req.Spans...); err != nil {
+	if err := validation.AddSpans(ctx, s.uploadedSpans, &s.uploadedSpansLock, s.delay, req.Spans...); err != nil {
 		return nil, err
 	}
 	return &empty.Empty{}, nil
@@ -63,7 +63,7 @@ func (s *MockTraceServer) CreateSpan(ctx context.Context, span *cloudtrace.Span)
 	if err := validation.ValidateSpans("CreateSpan", span); err != nil {
 		return nil, err
 	}
-	if err := validation.AddSpans(s.uploadedSpans, &s.uploadedSpansLock, s.delay, ctx, span); err != nil {
+	if err := validation.AddSpans(ctx, s.uploadedSpans, &s.uploadedSpansLock, s.delay, span); err != nil {
 		return nil, err
 	}
 	return span, nil

--- a/server/trace/mock_trace_test.go
+++ b/server/trace/mock_trace_test.go
@@ -131,7 +131,7 @@ func TestMockTraceServer_BatchWriteSpans(t *testing.T) {
 	defer tearDown()
 
 	spans := []*cloudtrace.Span{
-		generateSpan("test-span-1"),
+		generateSpan("projects/test-project/traces/fcf19faad74e6548537e942267d70752/spans/0f0f39d06d0b76f8"),
 		generateSpan("test-span-2"),
 		generateSpan("test-span-3"),
 	}
@@ -195,7 +195,7 @@ func TestMockTraceServer_BatchWriteSpans_InvalidTimestamp(t *testing.T) {
 		Name:  "test-project",
 		Spans: invalidTimestampSpans,
 	}
-	want := validation.ErrInvalidTimestamp
+	want := validation.StatusInvalidTimestamp
 
 	responseSpan, err := traceClient.BatchWriteSpans(ctx, in)
 	if err == nil {
@@ -220,7 +220,7 @@ func TestMockTraceServer_BatchWriteSpans_DuplicateName(t *testing.T) {
 		generateSpan(duplicateSpanName),
 	}
 	in := &cloudtrace.BatchWriteSpansRequest{Name: "test-project", Spans: spans}
-	want := validation.ErrDuplicateSpanName
+	want := validation.StatusDuplicateSpanName
 
 	responseSpan, err := traceClient.BatchWriteSpans(ctx, in)
 	if err == nil {
@@ -281,7 +281,7 @@ func TestMockTraceServer_CreateSpan_InvalidTimestamp(t *testing.T) {
 	defer tearDown()
 
 	in := generateInvalidTimestampSpan("test-span-1")
-	want := validation.ErrInvalidTimestamp
+	want := validation.StatusInvalidTimestamp
 
 	responseSpan, err := traceClient.CreateSpan(ctx, in)
 	if err == nil {


### PR DESCRIPTION
Adding in additional validations for tracing based on [this doc](https://docs.google.com/document/d/1eeGeSYlE2F-Dc-5_yLXnIlj7e--BYFeWlzWy6qBV2cg/edit#heading=h.dvfir8q4g0rp). The additional checks are

- Validating the project name and span names are in the correct format
- Validating that strings and truncated strings do not exceed the maximum lengths
- Validating that optional fields (attributes, time events, links, etc.) follow the correct format if present

Additional unit tests for these validations will be added in a separate PR since this one is already pretty large.

Since this involved creating a lot of new statuses, this PR also refactored them so that they're no longer exported, and the tests no longer do string comparison, as discussed in [this issue](https://github.com/googleinterns/cloud-operations-api-mock/issues/22). Lint issues for trace are also resolved in this PR.