### PR TITLE
Fix all lint errors

### DIFF
--- a/cloudmock/cloud_mock.go
+++ b/cloudmock/cloud_mock.go
@@ -27,6 +27,9 @@ import (
 	"google.golang.org/grpc"
 )
 
+// CloudMock is the struct we will expose to users to use in their tests.
+// It contains the gRPC clients for users to call, as well as the connection
+// info to allow a graceful shutdown after the tests run.
 type CloudMock struct {
 	conn                   *grpc.ClientConn
 	grpcServer             *grpc.Server
@@ -59,6 +62,8 @@ func startMockServer() (string, *grpc.Server) {
 	return lis.Addr().String(), grpcServer
 }
 
+// NewCloudMock is the constructor for the CloudMock struct, it will return a
+// pointer to a new CloudMock.
 func NewCloudMock() *CloudMock {
 	address, grpcServer := startMockServer()
 
@@ -79,10 +84,13 @@ func NewCloudMock() *CloudMock {
 	}
 }
 
+// ClientConn is a getter to retrieve the client connection. This is used
+// to provide the exporters with the address of our mock server.
 func (mock *CloudMock) ClientConn() *grpc.ClientConn {
 	return mock.conn
 }
 
+// Shutdown closes the connections and shuts down the gRPC server.
 func (mock *CloudMock) Shutdown() {
 	if err := mock.conn.Close(); err != nil {
 		log.Fatalf("failed to close connection: %s", err)

--- a/internal/validation/shared_validation.go
+++ b/internal/validation/shared_validation.go
@@ -19,18 +19,14 @@ import (
 	"reflect"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-)
-
-var (
-	ErrMissingField = status.New(codes.InvalidArgument, "missing required field(s)")
 )
 
 const (
 	missingFieldMsg = "%v must contain the required %v field"
 )
 
+// CheckForRequiredFields verifies that the required fields for the given request are present.
 func CheckForRequiredFields(requiredFields []string, reqReflect reflect.Value, requestName string) error {
 	br := &errdetails.BadRequest{}
 
@@ -45,7 +41,7 @@ func CheckForRequiredFields(requiredFields []string, reqReflect reflect.Value, r
 	}
 
 	if len(br.FieldViolations) > 0 {
-		st, err := ErrMissingField.WithDetails(br)
+		st, err := statusMissingField.WithDetails(br)
 		if err != nil {
 			panic(fmt.Sprintf("unexpected error attaching metadata: %v", err))
 		}
@@ -54,6 +50,7 @@ func CheckForRequiredFields(requiredFields []string, reqReflect reflect.Value, r
 	return nil
 }
 
+// ValidateErrDetails is used to test that the error details contain the correct missing fields.
 func ValidateErrDetails(err error, missingFields map[string]struct{}) bool {
 	st := status.Convert(err)
 	for _, detail := range st.Details() {

--- a/internal/validation/statuses.go
+++ b/internal/validation/statuses.go
@@ -53,4 +53,11 @@ var (
 	statusTooManyLinks = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("a span can have at most %v links", maxLinks))
 	statusDuplicateSpanName = status.New(codes.AlreadyExists, "duplicate span name")
+
+	// Metric statuses.
+	statusDuplicateMetricDescriptorName = status.New(codes.AlreadyExists, "metric descriptor with same name already exists")
+	statusMetricDescriptorNotFound      = status.New(codes.NotFound, "metric descriptor with given name does not exist")
+
+	// Shared statuses.
+	statusMissingField = status.New(codes.InvalidArgument, "missing required field(s)")
 )

--- a/server/metric/mock_metric.go
+++ b/server/metric/mock_metric.go
@@ -26,17 +26,22 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/status"
 )
 
+// MockMetricServer implements all of the RPCs pertaining to
+// tracing that can be called by the client. It also contains the
+// uploaded data.
 type MockMetricServer struct {
 	monitoring.UnimplementedMetricServiceServer
 	uploadedMetricDescriptors     map[string]*metric.MetricDescriptor
 	uploadedMetricDescriptorsLock sync.Mutex
 }
 
+// NewMockMetricServer creates a new MockMetricServer and returns a pointer to it.
 func NewMockMetricServer() *MockMetricServer {
 	uploadedMetricDescriptors := make(map[string]*metric.MetricDescriptor)
 	return &MockMetricServer{uploadedMetricDescriptors: uploadedMetricDescriptors}
 }
 
+// GetMonitoredResourceDescriptor returns the requested monitored resource descriptor if it exists.
 func (s *MockMetricServer) GetMonitoredResourceDescriptor(ctx context.Context, req *monitoring.GetMonitoredResourceDescriptorRequest,
 ) (*monitoredres.MonitoredResourceDescriptor, error) {
 	if err := validation.IsValidRequest(req); err != nil {
@@ -45,6 +50,8 @@ func (s *MockMetricServer) GetMonitoredResourceDescriptor(ctx context.Context, r
 	return &monitoredres.MonitoredResourceDescriptor{}, nil
 }
 
+// ListMonitoredResourceDescriptors list all the requested monitored resource descriptors
+// that are picked up by the given query.
 func (s *MockMetricServer) ListMonitoredResourceDescriptors(ctx context.Context, req *monitoring.ListMonitoredResourceDescriptorsRequest,
 ) (*monitoring.ListMonitoredResourceDescriptorsResponse, error) {
 	if err := validation.IsValidRequest(req); err != nil {
@@ -56,6 +63,8 @@ func (s *MockMetricServer) ListMonitoredResourceDescriptors(ctx context.Context,
 	}, nil
 }
 
+// GetMetricDescriptor returns the requested metric descriptor.
+// If it doesn't esxist, an error is returned.
 func (s *MockMetricServer) GetMetricDescriptor(ctx context.Context, req *monitoring.GetMetricDescriptorRequest,
 ) (*metric.MetricDescriptor, error) {
 	if err := validation.IsValidRequest(req); err != nil {
@@ -70,6 +79,8 @@ func (s *MockMetricServer) GetMetricDescriptor(ctx context.Context, req *monitor
 	return metricDescriptor, nil
 }
 
+// CreateMetricDescriptor stores the given metric descriptor in memory.
+// If it already exists, an error is returned.
 func (s *MockMetricServer) CreateMetricDescriptor(ctx context.Context, req *monitoring.CreateMetricDescriptorRequest,
 ) (*metric.MetricDescriptor, error) {
 	if err := validation.IsValidRequest(req); err != nil {
@@ -83,6 +94,8 @@ func (s *MockMetricServer) CreateMetricDescriptor(ctx context.Context, req *moni
 	return req.MetricDescriptor, nil
 }
 
+// DeleteMetricDescriptor deletes the given metric descriptor from memory.
+// If it doesn't exist, an error is returned.
 func (s *MockMetricServer) DeleteMetricDescriptor(ctx context.Context, req *monitoring.DeleteMetricDescriptorRequest,
 ) (*empty.Empty, error) {
 	if err := validation.IsValidRequest(req); err != nil {
@@ -96,6 +109,7 @@ func (s *MockMetricServer) DeleteMetricDescriptor(ctx context.Context, req *moni
 	return &empty.Empty{}, nil
 }
 
+// ListMetricDescriptors lists all the metric descriptors that are picked up by the given query.
 func (s *MockMetricServer) ListMetricDescriptors(ctx context.Context, req *monitoring.ListMetricDescriptorsRequest,
 ) (*monitoring.ListMetricDescriptorsResponse, error) {
 	if err := validation.IsValidRequest(req); err != nil {
@@ -107,6 +121,8 @@ func (s *MockMetricServer) ListMetricDescriptors(ctx context.Context, req *monit
 	}, nil
 }
 
+// CreateTimeSeries stores the given time series in memory.
+// If it already exists, an error is returned.
 func (s *MockMetricServer) CreateTimeSeries(ctx context.Context, req *monitoring.CreateTimeSeriesRequest,
 ) (*empty.Empty, error) {
 	if err := validation.IsValidRequest(req); err != nil {
@@ -115,6 +131,7 @@ func (s *MockMetricServer) CreateTimeSeries(ctx context.Context, req *monitoring
 	return &empty.Empty{}, nil
 }
 
+// ListTimeSeries lists all time series that are picked up by the given query.
 func (s *MockMetricServer) ListTimeSeries(ctx context.Context, req *monitoring.ListTimeSeriesRequest,
 ) (*monitoring.ListTimeSeriesResponse, error) {
 	if err := validation.IsValidRequest(req); err != nil {


### PR DESCRIPTION
This PR fix all the lint errors that arose after we added `golint` to the repo. This PR adds comments to exported functions/variables, fixes up some concurrent tests, and stops exporting all the statuses solely for the purpose of testing.