### PR TITLE
Switch key to type instead of name

### DIFF
--- a/internal/validation/mock_trace_validation.go
+++ b/internal/validation/mock_trace_validation.go
@@ -25,7 +25,6 @@ import (
 
 	"google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc/status"
 )
 
 const (
@@ -245,18 +244,4 @@ func validateLinks(links *cloudtrace.Span_Links) error {
 	}
 
 	return nil
-}
-
-// ValidateDuplicateSpanNames is used in tests to verify that the error returned
-// contains the correct span name (that is, the duplicate span name).
-func ValidateDuplicateSpanNames(err error, duplicateName string) bool {
-	st := status.Convert(err)
-	for _, detail := range st.Details() {
-		if t, ok := detail.(*errdetails.ErrorInfo); ok {
-			if t.GetReason() != duplicateName {
-				return false
-			}
-		}
-	}
-	return true
 }

--- a/internal/validation/shared_validation.go
+++ b/internal/validation/shared_validation.go
@@ -50,8 +50,8 @@ func CheckForRequiredFields(requiredFields []string, reqReflect reflect.Value, r
 	return nil
 }
 
-// ValidateErrDetails is used to test that the error details contain the correct missing fields.
-func ValidateErrDetails(err error, missingFields map[string]struct{}) bool {
+// ValidateMissingFieldsErrDetails is used to test that the error details contain the correct missing fields.
+func ValidateMissingFieldsErrDetails(err error, missingFields map[string]struct{}) bool {
 	st := status.Convert(err)
 	for _, detail := range st.Details() {
 		if t, ok := detail.(*errdetails.BadRequest); ok {
@@ -59,6 +59,20 @@ func ValidateErrDetails(err error, missingFields map[string]struct{}) bool {
 				if _, ok := missingFields[violation.GetField()]; !ok {
 					return false
 				}
+			}
+		}
+	}
+	return true
+}
+
+// ValidateDuplicateErrDetails is used in tests to verify that the error returned
+// contains the correct duplicated value.
+func ValidateDuplicateErrDetails(err error, duplicateName string) bool {
+	st := status.Convert(err)
+	for _, detail := range st.Details() {
+		if t, ok := detail.(*errdetails.ErrorInfo); ok {
+			if t.GetReason() != duplicateName {
+				return false
 			}
 		}
 	}

--- a/internal/validation/statuses.go
+++ b/internal/validation/statuses.go
@@ -54,8 +54,8 @@ var (
 	statusDuplicateSpanName = status.New(codes.AlreadyExists, "duplicate span name")
 
 	// Metric statuses.
-	statusDuplicateMetricDescriptorName = status.New(codes.AlreadyExists, "metric descriptor with same name already exists")
-	statusMetricDescriptorNotFound      = status.New(codes.NotFound, "metric descriptor with given name does not exist")
+	statusDuplicateMetricDescriptorType = status.New(codes.AlreadyExists, "metric descriptor of same type already exists")
+	statusMetricDescriptorNotFound      = status.New(codes.NotFound, "metric descriptor of given type does not exist")
 
 	// Shared statuses.
 	statusMissingField = status.New(codes.InvalidArgument, "missing required field(s)")

--- a/server/metric/mock_metric.go
+++ b/server/metric/mock_metric.go
@@ -71,7 +71,9 @@ func (s *MockMetricServer) GetMetricDescriptor(ctx context.Context, req *monitor
 		return nil, err
 	}
 
-	metricDescriptor, err := validation.AccessMetricDescriptor(&s.uploadedMetricDescriptorsLock, s.uploadedMetricDescriptors, req.Name)
+	s.uploadedMetricDescriptorsLock.Lock()
+	defer s.uploadedMetricDescriptorsLock.Unlock()
+	metricDescriptor, err := validation.AccessMetricDescriptor(s.uploadedMetricDescriptors, req.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +88,9 @@ func (s *MockMetricServer) CreateMetricDescriptor(ctx context.Context, req *moni
 	if err := validation.IsValidRequest(req); err != nil {
 		return nil, err
 	}
-
-	if err := validation.AddMetricDescriptor(&s.uploadedMetricDescriptorsLock, s.uploadedMetricDescriptors, req.MetricDescriptor.Name, req.MetricDescriptor); err != nil {
+	s.uploadedMetricDescriptorsLock.Lock()
+	defer s.uploadedMetricDescriptorsLock.Unlock()
+	if err := validation.AddMetricDescriptor(s.uploadedMetricDescriptors, req.MetricDescriptor.Type, req.MetricDescriptor); err != nil {
 		return nil, err
 	}
 
@@ -102,7 +105,9 @@ func (s *MockMetricServer) DeleteMetricDescriptor(ctx context.Context, req *moni
 		return nil, err
 	}
 
-	if err := validation.RemoveMetricDescriptor(&s.uploadedMetricDescriptorsLock, s.uploadedMetricDescriptors, req.Name); err != nil {
+	s.uploadedMetricDescriptorsLock.Lock()
+	defer s.uploadedMetricDescriptorsLock.Unlock()
+	if err := validation.RemoveMetricDescriptor(s.uploadedMetricDescriptors, req.Name); err != nil {
 		return nil, err
 	}
 

--- a/server/trace/mock_trace_test.go
+++ b/server/trace/mock_trace_test.go
@@ -214,7 +214,7 @@ func TestMockTraceServer_BatchWriteSpans_MissingField(t *testing.T) {
 		return
 	}
 
-	if valid := validation.ValidateErrDetails(err, missingFields); !valid {
+	if valid := validation.ValidateMissingFieldsErrDetails(err, missingFields); !valid {
 		t.Errorf("BatchWriteSpans(%v) expected missing fields %v", in, missingFields)
 	}
 }
@@ -259,7 +259,7 @@ func TestMockTraceServer_BatchWriteSpans_DuplicateName(t *testing.T) {
 			in, responseSpan, want)
 	}
 
-	if valid := validation.ValidateDuplicateSpanNames(err, duplicateSpan.Name); !valid {
+	if valid := validation.ValidateDuplicateErrDetails(err, duplicateSpan.Name); !valid {
 		t.Errorf("expected duplicate spanName: %v", duplicateSpan.Name)
 	}
 }
@@ -321,7 +321,7 @@ func TestMockTraceServer_CreateSpan_MissingFields(t *testing.T) {
 		return
 	}
 
-	if valid := validation.ValidateErrDetails(err, missingFields); !valid {
+	if valid := validation.ValidateMissingFieldsErrDetails(err, missingFields); !valid {
 		t.Errorf("CreateSpan(%v) expected missing fields %v", in, missingFields)
 	}
 }
@@ -358,7 +358,7 @@ func TestMockTraceServer_CreateSpan_DuplicateName(t *testing.T) {
 		t.Errorf("CreateSpan(%v) returned %v, expected error %v", duplicateSpan, resp, want)
 	}
 
-	if valid := validation.ValidateDuplicateSpanNames(err, duplicateSpan.Name); !valid {
+	if valid := validation.ValidateDuplicateErrDetails(err, duplicateSpan.Name); !valid {
 		t.Errorf("expected duplicate spanName: %v", duplicateSpan.Name)
 	}
 }


### PR DESCRIPTION
Metric descriptors are unique based on their `type`, not their `name`. Switch the key of the map of `MetricDescriptors` to be the type instead.