### PR TITLE
Add validation for CreateTimeSeries

### DIFF
--- a/internal/validation/mock_metric_validation.go
+++ b/internal/validation/mock_metric_validation.go
@@ -17,15 +17,24 @@ package validation
 import (
 	"fmt"
 	"reflect"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
 
 	"google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 )
 
-// IsValidRequest verifies that the given request is valid.
-// This means required fields are present and all fields semantically make sense.
-func IsValidRequest(req interface{}) error {
+const (
+	// Time series constraints can be found at https://cloud.google.com/monitoring/quotas#custom_metrics_quotas.
+	maxTimeSeriesPerRequest      = 200
+	maxTimeSeriesLabelKeyBytes   = 100
+	maxTimeSeriesLabelValueBytes = 1024
+)
+
+// ValidRequiredFields verifies that the given request contains the required fields.
+func ValidRequiredFields(req interface{}) error {
 	reqReflect := reflect.ValueOf(req)
 	requiredFields := []string{"Name"}
 	requestName := ""
@@ -102,6 +111,119 @@ func RemoveMetricDescriptor(uploadedMetricDescriptors map[string]*metric.MetricD
 	}
 
 	delete(uploadedMetricDescriptors, metricType)
+
+	return nil
+}
+
+// ValidateCreateTimeSeries checks that the given TimeSeries conform to the API requirements.
+func ValidateCreateTimeSeries(timeSeries []*monitoring.TimeSeries, descriptors map[string]*metric.MetricDescriptor) error {
+	if len(timeSeries) > maxTimeSeriesPerRequest {
+		return statusTooManyTimeSeries
+	}
+
+	for _, ts := range timeSeries {
+		// Check that required fields for time series are present.
+		if ts.Metric == nil || len(ts.Points) != 1 || ts.Resource == nil {
+			return statusInvalidTimeSeries
+		}
+
+		// Check that the metric labels follow the constraints.
+		for k, v := range ts.Metric.Labels {
+			if len(k) > maxTimeSeriesLabelKeyBytes {
+				return statusInvalidTimeSeriesLabelKey
+			}
+
+			if len(v) > maxTimeSeriesLabelValueBytes {
+				return statusInvalidTimeSeriesLabelValue
+			}
+		}
+
+		if err := validateMetricKind(ts, descriptors); err != nil {
+			return err
+		}
+
+		if err := validateValueType(ts.ValueType, ts.Points[0]); err != nil {
+			return err
+		}
+
+		if err := validatePoint(ts.MetricKind, ts.Points[0]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateMetricKind check that if metric_kind is present,
+// it is the same as the metricKind of the associated metric.
+func validateMetricKind(timeSeries *monitoring.TimeSeries, descriptors map[string]*metric.MetricDescriptor) error {
+	descriptor := descriptors[timeSeries.Metric.Type]
+	if descriptor == nil {
+		return statusMissingMetricDescriptor
+	}
+	if descriptor.MetricKind != timeSeries.MetricKind {
+		return statusInvalidTimeSeriesMetricKind
+	}
+
+	return nil
+}
+
+// validateValueType checks that if TimeSeries' "value_type" is present,
+// it is the same as the type of the data in the "points" field.
+func validateValueType(valueType metric.MetricDescriptor_ValueType, point *monitoring.Point) error {
+	if valueType == metric.MetricDescriptor_BOOL {
+		if _, ok := point.Value.Value.(*monitoring.TypedValue_BoolValue); !ok {
+			return statusInvalidTimeSeriesValueType
+		}
+	}
+	if valueType == metric.MetricDescriptor_INT64 {
+		if _, ok := point.Value.Value.(*monitoring.TypedValue_Int64Value); !ok {
+			return statusInvalidTimeSeriesValueType
+		}
+	}
+	if valueType == metric.MetricDescriptor_DOUBLE {
+		if _, ok := point.Value.Value.(*monitoring.TypedValue_DoubleValue); !ok {
+			return statusInvalidTimeSeriesValueType
+		}
+	}
+	if valueType == metric.MetricDescriptor_STRING {
+		if _, ok := point.Value.Value.(*monitoring.TypedValue_StringValue); !ok {
+			return statusInvalidTimeSeriesValueType
+		}
+	}
+	if valueType == metric.MetricDescriptor_DISTRIBUTION {
+		if _, ok := point.Value.Value.(*monitoring.TypedValue_DistributionValue); !ok {
+			return statusInvalidTimeSeriesValueType
+		}
+	}
+
+	return nil
+}
+
+// validatePoint checks that the data for the point is valid.
+// The specifics checks depend on the metric_kind.
+func validatePoint(metricKind metric.MetricDescriptor_MetricKind, point *monitoring.Point) error {
+	startTime, err := ptypes.Timestamp(point.Interval.StartTime)
+	// If metric_kind is GAUGE, the startTime is optional.
+	if err != nil && metricKind != metric.MetricDescriptor_GAUGE {
+		return statusMalformedTimestamp
+	}
+	endTime, err := ptypes.Timestamp(point.Interval.EndTime)
+	if err != nil {
+		return statusMalformedTimestamp
+	}
+
+	// If metric_kind is GAUGE, if start time is supplied, it must equal the end time.
+	if metricKind == metric.MetricDescriptor_GAUGE {
+		// If start time is nil, ptypes.Timestamp will return time.Unix(0, 0).UTC().
+		if startTime != time.Unix(0, 0).UTC() && !startTime.Equal(endTime) {
+			return statusInvalidTimeSeriesPointGauge
+		}
+	}
+
+	// TODO (ejwang): also need checks for metric.MetricDescriptor_DELTA and metric.MetricDescriptor_CUMULATIVE,
+	//  however they involve comparing against previous time series, so we'll need to store time series in memory.
+	//  Leaving this for another PR since this PR is already quite large.
 
 	return nil
 }

--- a/internal/validation/mock_trace_validation.go
+++ b/internal/validation/mock_trace_validation.go
@@ -38,12 +38,22 @@ const (
 	maxDisplayNameBytes     = 128
 	maxLinks                = 128
 	maxTimeEvents           = 32
+
+	agent          = "g.co/agent"
+	shortenedAgent = "agent"
 )
 
 var (
-	requiredFields   = []string{"Name", "SpanId", "DisplayName", "StartTime", "EndTime"}
-	spanNameRegex    = regexp.MustCompile("^projects/[^/]+/traces/[a-fA-F0-9]{32}/spans/[a-fA-F0-9]{16}$")
-	projectNameRegex = regexp.MustCompile("^projects/[^/]+$")
+	// The exporter is responsible for mapping these special attributes to the correct
+	// canonical Cloud Trace attributes (/http/method, /http/route, etc.)
+	specialAttributes = map[string]struct{}{
+		"http.method":      {},
+		"http.route":       {},
+		"http.status_code": {},
+	}
+	requiredFields = []string{"Name", "SpanId", "DisplayName", "StartTime", "EndTime"}
+	spanNameRegex  = regexp.MustCompile("^projects/[^/]+/traces/[a-fA-F0-9]{32}/spans/[a-fA-F0-9]{16}$")
+	agentRegex     = regexp.MustCompile(`^opentelemetry-[a-zA-Z]+ [0-9]+\.[0-9]+\.[0-9]+; google-cloud-trace-exporter [0-9]+\.[0-9]+\.[0-9]+$`)
 )
 
 // ValidateSpans checks that the spans conform to the API requirements.
@@ -119,15 +129,6 @@ func AccessSpan(index int, uploadedSpans []*cloudtrace.Span) *cloudtrace.Span {
 	return uploadedSpans[index]
 }
 
-// ValidateProjectName verifies that the project name from the BatchWriteSpans request
-// is of the form projects/[PROJECT_ID]
-func ValidateProjectName(projectName string) error {
-	if !projectNameRegex.MatchString(projectName) {
-		return statusInvalidProjectName
-	}
-	return nil
-}
-
 // validateDisplayName verifies that the display name has at most 128 bytes.
 func validateDisplayName(displayName *cloudtrace.TruncatableString) error {
 	if len(displayName.Value) > maxDisplayNameBytes {
@@ -174,17 +175,46 @@ func validateAttributes(attributes *cloudtrace.Span_Attributes, maxAttributes in
 		return statusTooManyAttributes
 	}
 
+	containsAgent := false
+
 	for k, v := range attributes.AttributeMap {
 		if len(k) > maxAttributeKeyBytes {
 			return statusInvalidAttributeKey
 		}
+
+		// Ensure that the special attributes have been translated properly.
+		if _, ok := specialAttributes[k]; ok {
+			return statusUnmappedSpecialAttribute
+		}
+
 		if val, ok := v.Value.(*cloudtrace.AttributeValue_StringValue); ok {
 			if len(val.StringValue.Value) > maxAttributeValueBytes {
 				return statusInvalidAttributeValue
 			}
+
+			// The span must contain the attribute "g.co/agent" or "agent".
+			if k == agent || k == shortenedAgent {
+				containsAgent = true
+				if err := validateAgent(val.StringValue.Value); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
+	if !containsAgent {
+		return statusMissingAgentAttribute
+	}
+
+	return nil
+}
+
+// validateAgent checks that the g.co/agent or agent attribute is of the form
+// opentelemetry-<language_code> <ot_version>; google-cloud-trace-exporter <exporter_version>
+func validateAgent(agent string) error {
+	if !agentRegex.MatchString(agent) {
+		return statusInvalidAgentAttribute
+	}
 	return nil
 }
 

--- a/internal/validation/shared_validation.go
+++ b/internal/validation/shared_validation.go
@@ -17,6 +17,7 @@ package validation
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/status"
@@ -24,6 +25,10 @@ import (
 
 const (
 	missingFieldMsg = "%v must contain the required %v field"
+)
+
+var (
+	projectNameRegex = regexp.MustCompile("^projects/[^/]+$")
 )
 
 // CheckForRequiredFields verifies that the required fields for the given request are present.
@@ -77,4 +82,13 @@ func ValidateDuplicateErrDetails(err error, duplicateName string) bool {
 		}
 	}
 	return true
+}
+
+// ValidateProjectName verifies that the project name from the BatchWriteSpans request
+// is of the form projects/[PROJECT_ID]
+func ValidateProjectName(projectName string) error {
+	if !projectNameRegex.MatchString(projectName) {
+		return statusInvalidProjectName
+	}
+	return nil
 }

--- a/internal/validation/statuses.go
+++ b/internal/validation/statuses.go
@@ -45,6 +45,11 @@ var (
 		fmt.Sprintf("attribute keys have a max length of %v bytes", maxAttributeKeyBytes))
 	statusInvalidAttributeValue = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("attribute values have a max length of %v bytes", maxAttributeValueBytes))
+	statusInvalidAgentAttribute = status.Error(codes.InvalidArgument,
+		"agent attribute must be of the form opentelemetry-<language_code> <ot_version>; google-cloud-trace-exporter <exporter_version>")
+	statusMissingAgentAttribute    = status.Error(codes.InvalidArgument, "attributes must contain either g.co/agent or agent")
+	statusUnmappedSpecialAttribute = status.Error(codes.InvalidArgument,
+		"http.method, http.route and http.status_code should be translated to /http/method, /http/route and /http/status_code respectively")
 	statusTooManyTimeEvents = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("a span can have at most %v time events", maxTimeEvents))
 	statusInvalidAnnotation = status.Error(codes.InvalidArgument,
@@ -56,6 +61,22 @@ var (
 	// Metric statuses.
 	statusDuplicateMetricDescriptorType = status.New(codes.AlreadyExists, "metric descriptor of same type already exists")
 	statusMetricDescriptorNotFound      = status.New(codes.NotFound, "metric descriptor of given type does not exist")
+	statusTooManyTimeSeries             = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("maximum number of time series per request is %v", maxTimeSeriesPerRequest))
+	statusInvalidTimeSeries = status.Error(codes.InvalidArgument,
+		"time series require fields metric, resource, exactly one point")
+	statusInvalidTimeSeriesLabelKey = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("time series metric label keys have a max length of %v bytes", maxTimeSeriesLabelKeyBytes))
+	statusInvalidTimeSeriesLabelValue = status.Error(codes.InvalidArgument,
+		fmt.Sprintf("time series metric label values have a max length of %v bytes", maxTimeSeriesLabelValueBytes))
+	statusInvalidTimeSeriesValueType = status.Error(codes.InvalidArgument,
+		"time series' value_type field must be the same as the type of the data in the points field")
+	statusMissingMetricDescriptor = status.Error(codes.InvalidArgument,
+		"corresponding metric descriptor for given time series does not exist")
+	statusInvalidTimeSeriesMetricKind = status.Error(codes.InvalidArgument,
+		"metric kind must be the same as the metric kind of the associated metric")
+	statusInvalidTimeSeriesPointGauge = status.Error(codes.InvalidArgument,
+		"for a GAUGE metric kind, the point's start time must equal the end time")
 
 	// Shared statuses.
 	statusMissingField = status.New(codes.InvalidArgument, "missing required field(s)")

--- a/server/metric/mock_metric.go
+++ b/server/metric/mock_metric.go
@@ -44,7 +44,7 @@ func NewMockMetricServer() *MockMetricServer {
 // GetMonitoredResourceDescriptor returns the requested monitored resource descriptor if it exists.
 func (s *MockMetricServer) GetMonitoredResourceDescriptor(ctx context.Context, req *monitoring.GetMonitoredResourceDescriptorRequest,
 ) (*monitoredres.MonitoredResourceDescriptor, error) {
-	if err := validation.IsValidRequest(req); err != nil {
+	if err := validation.ValidRequiredFields(req); err != nil {
 		return nil, err
 	}
 	return &monitoredres.MonitoredResourceDescriptor{}, nil
@@ -54,7 +54,7 @@ func (s *MockMetricServer) GetMonitoredResourceDescriptor(ctx context.Context, r
 // that are picked up by the given query.
 func (s *MockMetricServer) ListMonitoredResourceDescriptors(ctx context.Context, req *monitoring.ListMonitoredResourceDescriptorsRequest,
 ) (*monitoring.ListMonitoredResourceDescriptorsResponse, error) {
-	if err := validation.IsValidRequest(req); err != nil {
+	if err := validation.ValidRequiredFields(req); err != nil {
 		return nil, err
 	}
 	return &monitoring.ListMonitoredResourceDescriptorsResponse{
@@ -67,7 +67,7 @@ func (s *MockMetricServer) ListMonitoredResourceDescriptors(ctx context.Context,
 // If it doesn't esxist, an error is returned.
 func (s *MockMetricServer) GetMetricDescriptor(ctx context.Context, req *monitoring.GetMetricDescriptorRequest,
 ) (*metric.MetricDescriptor, error) {
-	if err := validation.IsValidRequest(req); err != nil {
+	if err := validation.ValidRequiredFields(req); err != nil {
 		return nil, err
 	}
 
@@ -85,7 +85,7 @@ func (s *MockMetricServer) GetMetricDescriptor(ctx context.Context, req *monitor
 // If it already exists, an error is returned.
 func (s *MockMetricServer) CreateMetricDescriptor(ctx context.Context, req *monitoring.CreateMetricDescriptorRequest,
 ) (*metric.MetricDescriptor, error) {
-	if err := validation.IsValidRequest(req); err != nil {
+	if err := validation.ValidRequiredFields(req); err != nil {
 		return nil, err
 	}
 	s.uploadedMetricDescriptorsLock.Lock()
@@ -101,7 +101,7 @@ func (s *MockMetricServer) CreateMetricDescriptor(ctx context.Context, req *moni
 // If it doesn't exist, an error is returned.
 func (s *MockMetricServer) DeleteMetricDescriptor(ctx context.Context, req *monitoring.DeleteMetricDescriptorRequest,
 ) (*empty.Empty, error) {
-	if err := validation.IsValidRequest(req); err != nil {
+	if err := validation.ValidRequiredFields(req); err != nil {
 		return nil, err
 	}
 
@@ -117,7 +117,7 @@ func (s *MockMetricServer) DeleteMetricDescriptor(ctx context.Context, req *moni
 // ListMetricDescriptors lists all the metric descriptors that are picked up by the given query.
 func (s *MockMetricServer) ListMetricDescriptors(ctx context.Context, req *monitoring.ListMetricDescriptorsRequest,
 ) (*monitoring.ListMetricDescriptorsResponse, error) {
-	if err := validation.IsValidRequest(req); err != nil {
+	if err := validation.ValidRequiredFields(req); err != nil {
 		return nil, err
 	}
 	return &monitoring.ListMetricDescriptorsResponse{
@@ -130,7 +130,13 @@ func (s *MockMetricServer) ListMetricDescriptors(ctx context.Context, req *monit
 // If it already exists, an error is returned.
 func (s *MockMetricServer) CreateTimeSeries(ctx context.Context, req *monitoring.CreateTimeSeriesRequest,
 ) (*empty.Empty, error) {
-	if err := validation.IsValidRequest(req); err != nil {
+	if err := validation.ValidRequiredFields(req); err != nil {
+		return nil, err
+	}
+	if err := validation.ValidateProjectName(req.Name); err != nil {
+		return nil, err
+	}
+	if err := validation.ValidateCreateTimeSeries(req.TimeSeries, s.uploadedMetricDescriptors); err != nil {
 		return nil, err
 	}
 	return &empty.Empty{}, nil
@@ -139,7 +145,7 @@ func (s *MockMetricServer) CreateTimeSeries(ctx context.Context, req *monitoring
 // ListTimeSeries lists all time series that are picked up by the given query.
 func (s *MockMetricServer) ListTimeSeries(ctx context.Context, req *monitoring.ListTimeSeriesRequest,
 ) (*monitoring.ListTimeSeriesResponse, error) {
-	if err := validation.IsValidRequest(req); err != nil {
+	if err := validation.ValidRequiredFields(req); err != nil {
 		return nil, err
 	}
 	return &monitoring.ListTimeSeriesResponse{


### PR DESCRIPTION
Adding in some validation for the `CreateTimeSeries` endpoint. Validation are from [here](https://docs.google.com/document/d/1eeGeSYlE2F-Dc-5_yLXnIlj7e--BYFeWlzWy6qBV2cg/edit#heading=h.nhu541bsafyk). There are other checks we should make (rate limits, validating intervals are contiguous between points etc.), but they will involve storing points in memory, which I will do in a separate PR since this one is getting large.