### PR TITLE
Don't store spans during CreateSpan

### DIFF
--- a/server/trace/mock_trace.go
+++ b/server/trace/mock_trace.go
@@ -72,14 +72,6 @@ func (s *MockTraceServer) CreateSpan(ctx context.Context, span *cloudtrace.Span)
 	if err := validation.ValidateSpans("CreateSpan", span); err != nil {
 		return nil, err
 	}
-	if err := validation.Delay(ctx, s.delay); err != nil {
-		return nil, err
-	}
-	s.uploadedSpansLock.Lock()
-	defer s.uploadedSpansLock.Unlock()
-	if err := validation.AddSpans(&s.uploadedSpans, s.uploadedSpanNames, span); err != nil {
-		return nil, err
-	}
 	return span, nil
 }
 


### PR DESCRIPTION
According to the Go and Python exporter teams, `CreateSpan` is not actually used in any of the exporters, and moreover it's not supposed to actually write the spans, just perform some validation. Removing the code that actually writes the spans to memory from this method.