### PR TITLE
Add checks for rate limit, compare against previous point

### DIFF
--- a/internal/validation/mock_metric_validation.go
+++ b/internal/validation/mock_metric_validation.go
@@ -17,6 +17,7 @@ package validation
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
@@ -33,8 +34,15 @@ const (
 	maxTimeSeriesLabelValueBytes = 1024
 )
 
-// ValidRequiredFields verifies that the given request contains the required fields.
-func ValidRequiredFields(req interface{}) error {
+// PreviousPoint contains information about the most recently uploaded
+// point for a time series.
+type PreviousPoint struct {
+	Point *monitoring.Point
+	Time  time.Time
+}
+
+// ValidateRequiredFields verifies that the given request contains the required fields.
+func ValidateRequiredFields(req interface{}) error {
 	reqReflect := reflect.ValueOf(req)
 	requiredFields := []string{"Name"}
 	requestName := ""
@@ -115,8 +123,24 @@ func RemoveMetricDescriptor(uploadedMetricDescriptors map[string]*metric.MetricD
 	return nil
 }
 
+// ValidateRateLimit validates that the rate at which points are written does not
+// exceed the limit. The limit is one point every 10 seconds.
+func ValidateRateLimit(timeSeries []*monitoring.TimeSeries, uploadedPoints map[string]*PreviousPoint) error {
+	for _, ts := range timeSeries {
+		tsSerial := serializeTimeSeries(ts)
+		if p, ok := uploadedPoints[tsSerial]; ok {
+			if time.Since(p.Time) < (10 * time.Second) {
+				return statusTimeSeriesRateLimitExceeded
+			}
+		}
+	}
+
+	return nil
+}
+
 // ValidateCreateTimeSeries checks that the given TimeSeries conform to the API requirements.
-func ValidateCreateTimeSeries(timeSeries []*monitoring.TimeSeries, descriptors map[string]*metric.MetricDescriptor) error {
+func ValidateCreateTimeSeries(timeSeries []*monitoring.TimeSeries, descriptors map[string]*metric.MetricDescriptor,
+	uploadedPoints map[string]*PreviousPoint) error {
 	if len(timeSeries) > maxTimeSeriesPerRequest {
 		return statusTooManyTimeSeries
 	}
@@ -146,7 +170,7 @@ func ValidateCreateTimeSeries(timeSeries []*monitoring.TimeSeries, descriptors m
 			return err
 		}
 
-		if err := validatePoint(ts.MetricKind, ts.Points[0]); err != nil {
+		if err := validatePoint(ts, uploadedPoints); err != nil {
 			return err
 		}
 	}
@@ -202,28 +226,114 @@ func validateValueType(valueType metric.MetricDescriptor_ValueType, point *monit
 
 // validatePoint checks that the data for the point is valid.
 // The specifics checks depend on the metric_kind.
-func validatePoint(metricKind metric.MetricDescriptor_MetricKind, point *monitoring.Point) error {
-	startTime, err := ptypes.Timestamp(point.Interval.StartTime)
-	// If metric_kind is GAUGE, the startTime is optional.
-	if err != nil && metricKind != metric.MetricDescriptor_GAUGE {
-		return statusMalformedTimestamp
+func validatePoint(ts *monitoring.TimeSeries, uploadedPoints map[string]*PreviousPoint) error {
+	tsSerial := serializeTimeSeries(ts)
+	currentPoint := ts.Points[0]
+	prevPoint := uploadedPoints[tsSerial]
+	metricKind := ts.MetricKind
+
+	if currentPoint.Interval == nil {
+		return statusPointMissingInterval
 	}
-	endTime, err := ptypes.Timestamp(point.Interval.EndTime)
+
+	// Convert proto timestamps to Go's time.Time
+	startTime, endTime, err := convertPointInterval(currentPoint, metricKind)
 	if err != nil {
 		return statusMalformedTimestamp
 	}
-
-	// If metric_kind is GAUGE, if start time is supplied, it must equal the end time.
-	if metricKind == metric.MetricDescriptor_GAUGE {
-		// If start time is nil, ptypes.Timestamp will return time.Unix(0, 0).UTC().
-		if startTime != time.Unix(0, 0).UTC() && !startTime.Equal(endTime) {
-			return statusInvalidTimeSeriesPointGauge
+	var prevStartTime, prevEndTime time.Time
+	if prevPoint != nil {
+		prevStartTime, prevEndTime, err = convertPointInterval(prevPoint.Point, metricKind)
+		if err != nil {
+			return statusMalformedTimestamp
 		}
 	}
 
-	// TODO (ejwang): also need checks for metric.MetricDescriptor_DELTA and metric.MetricDescriptor_CUMULATIVE,
-	//  however they involve comparing against previous time series, so we'll need to store time series in memory.
-	//  Leaving this for another PR since this PR is already quite large.
+	// For GAUGE metrics, if start time is supplied, it must equal the end time.
+	if metricKind == metric.MetricDescriptor_GAUGE {
+		// If start time is nil, ptypes.Timestamp will return time.Unix(0, 0).UTC().
+		if startTime != time.Unix(0, 0).UTC() && !startTime.Equal(endTime) {
+			return statusInvalidGaugePoint
+		}
+	}
+
+	// For DELTA metrics, the start and end time should specify a non-zero interval,
+	// with subsequent points specifying contiguous and non-overlapping intervals.
+	if metricKind == metric.MetricDescriptor_DELTA {
+		if !startTime.Before(endTime) {
+			return statusInvalidInterval
+		}
+
+		if prevPoint != nil && !prevEndTime.Equal(startTime) {
+			return statusInvalidDeltaPoint
+		}
+	}
+
+	// For CUMULATIVE metrics, the start and end time should specify a non-zero interval,
+	// with subsequent points specifying the same start time and increasing end times,
+	// until an event resets the cumulative value to zero and sets a new start time.
+	if metricKind == metric.MetricDescriptor_CUMULATIVE {
+		if !startTime.Before(endTime) {
+			return statusInvalidInterval
+		}
+
+		if prevPoint != nil && !startTime.Equal(prevStartTime) || !endTime.After(prevEndTime) {
+			return statusInvalidCumulativePoint
+		}
+	}
 
 	return nil
+}
+
+// convertPointTimestamps converts a Point's interval
+// from proto's timestamp to Go's time.Time for easy comparison.
+func convertPointInterval(point *monitoring.Point, metricKind metric.MetricDescriptor_MetricKind) (time.Time, time.Time, error) {
+	startTime, err := ptypes.Timestamp(point.Interval.StartTime)
+	if err != nil && metricKind != metric.MetricDescriptor_GAUGE {
+		return startTime, time.Unix(0, 0).UTC(), statusMalformedTimestamp
+	}
+	endTime, err := ptypes.Timestamp(point.Interval.EndTime)
+	if err != nil {
+		return startTime, endTime, statusMalformedTimestamp
+	}
+
+	return startTime, endTime, nil
+}
+
+// serializeTimeSeries is used to uniquely serialize the time series.
+// The combination of both the metric and resource fields uniquely identify a TimeSeries.
+// The order is <metric_type>[<metric_key><metric_value>]<resource_type>[<resource_key><resource_Value>]
+func serializeTimeSeries(ts *monitoring.TimeSeries) string {
+	var result strings.Builder
+
+	// Add metric type.
+	result.WriteString(ts.Metric.Type)
+
+	// Add metric labels.
+	for k, v := range ts.Metric.Labels {
+		result.WriteString(k)
+		result.WriteString(v)
+	}
+
+	// Add resource type.
+	result.WriteString(ts.Resource.Type)
+
+	// Add resource labels.
+	for k, v := range ts.Resource.Labels {
+		result.WriteString(k)
+		result.WriteString(v)
+	}
+
+	return result.String()
+}
+
+// AddPoint sets the latest point to be the current point for a given time series.
+func AddPoint(timeSeries []*monitoring.TimeSeries, uploadedPoints map[string]*PreviousPoint) {
+	for _, ts := range timeSeries {
+		tsSerial := serializeTimeSeries(ts)
+		uploadedPoints[tsSerial] = &PreviousPoint{
+			Point: ts.Points[0],
+			Time:  time.Now(),
+		}
+	}
 }

--- a/internal/validation/mock_trace_validation.go
+++ b/internal/validation/mock_trace_validation.go
@@ -159,7 +159,7 @@ func validateTimeStamps(span *cloudtrace.Span) error {
 	}
 
 	if !start.Before(end) {
-		return statusInvalidTimestamp
+		return statusInvalidInterval
 	}
 	return nil
 }

--- a/internal/validation/statuses.go
+++ b/internal/validation/statuses.go
@@ -80,11 +80,11 @@ var (
 	statusPointMissingInterval = status.Error(codes.InvalidArgument,
 		"points must have a non-empty interval field")
 	statusInvalidGaugePoint = status.Error(codes.InvalidArgument,
-		"if start time for a gauge point is provided, the start time must equal the end time")
-	statusInvalidDeltaPoint = status.Error(codes.InvalidArgument,
-		"delta points must be contiguous and overlapping, and have a non-zero interval")
+		"if start time for a GAUGE point is provided, the start time must equal the end time")
+	statusDeltaNotSupported = status.Error(codes.InvalidArgument,
+		"DELTA is not supported for custom metrics")
 	statusInvalidCumulativePoint = status.Error(codes.InvalidArgument,
-		"cumulative points must have the same start time and increasing end times, and have a non-zero interval")
+		"CUMULATIVE points must have the same start time and increasing end times, and have a non-zero interval")
 
 	// Shared statuses.
 	statusMissingField = status.New(codes.InvalidArgument, "missing required field(s)")

--- a/internal/validation/statuses.go
+++ b/internal/validation/statuses.go
@@ -27,8 +27,8 @@ var (
 		"span name must be of the form projects/{project_id}/traces/{trace_id}/spans/{span_id}")
 	statusInvalidProjectName = status.Error(codes.InvalidArgument,
 		"project name must be of the form projects/{project_id}")
-	statusInvalidTimestamp = status.Error(codes.InvalidArgument,
-		"start time must be before end time")
+	statusInvalidInterval = status.Error(codes.InvalidArgument,
+		"start and end time must specify a non-zero interval")
 	statusMalformedTimestamp = status.Error(codes.InvalidArgument,
 		"unable to parse timestamp")
 	statusTimeEventMissingTime = status.Error(codes.InvalidArgument,
@@ -61,7 +61,9 @@ var (
 	// Metric statuses.
 	statusDuplicateMetricDescriptorType = status.New(codes.AlreadyExists, "metric descriptor of same type already exists")
 	statusMetricDescriptorNotFound      = status.New(codes.NotFound, "metric descriptor of given type does not exist")
-	statusTooManyTimeSeries             = status.Error(codes.InvalidArgument,
+	statusTimeSeriesRateLimitExceeded   = status.Error(codes.Aborted,
+		"maximum rate at which data can be written to a time series is one point every 10 seconds")
+	statusTooManyTimeSeries = status.Error(codes.InvalidArgument,
 		fmt.Sprintf("maximum number of time series per request is %v", maxTimeSeriesPerRequest))
 	statusInvalidTimeSeries = status.Error(codes.InvalidArgument,
 		"time series require fields metric, resource, exactly one point")
@@ -75,8 +77,14 @@ var (
 		"corresponding metric descriptor for given time series does not exist")
 	statusInvalidTimeSeriesMetricKind = status.Error(codes.InvalidArgument,
 		"metric kind must be the same as the metric kind of the associated metric")
-	statusInvalidTimeSeriesPointGauge = status.Error(codes.InvalidArgument,
-		"for a GAUGE metric kind, the point's start time must equal the end time")
+	statusPointMissingInterval = status.Error(codes.InvalidArgument,
+		"points must have a non-empty interval field")
+	statusInvalidGaugePoint = status.Error(codes.InvalidArgument,
+		"if start time for a gauge point is provided, the start time must equal the end time")
+	statusInvalidDeltaPoint = status.Error(codes.InvalidArgument,
+		"delta points must be contiguous and overlapping, and have a non-zero interval")
+	statusInvalidCumulativePoint = status.Error(codes.InvalidArgument,
+		"cumulative points must have the same start time and increasing end times, and have a non-zero interval")
 
 	// Shared statuses.
 	statusMissingField = status.New(codes.InvalidArgument, "missing required field(s)")

--- a/server/metric/mock_metric.go
+++ b/server/metric/mock_metric.go
@@ -33,18 +33,24 @@ type MockMetricServer struct {
 	monitoring.UnimplementedMetricServiceServer
 	uploadedMetricDescriptors     map[string]*metric.MetricDescriptor
 	uploadedMetricDescriptorsLock sync.Mutex
+	uploadedPoints                map[string]*validation.PreviousPoint
+	uploadedPointsLock            sync.Mutex
 }
 
 // NewMockMetricServer creates a new MockMetricServer and returns a pointer to it.
 func NewMockMetricServer() *MockMetricServer {
 	uploadedMetricDescriptors := make(map[string]*metric.MetricDescriptor)
-	return &MockMetricServer{uploadedMetricDescriptors: uploadedMetricDescriptors}
+	uploadedPoints := make(map[string]*validation.PreviousPoint)
+	return &MockMetricServer{
+		uploadedMetricDescriptors: uploadedMetricDescriptors,
+		uploadedPoints:            uploadedPoints,
+	}
 }
 
 // GetMonitoredResourceDescriptor returns the requested monitored resource descriptor if it exists.
 func (s *MockMetricServer) GetMonitoredResourceDescriptor(ctx context.Context, req *monitoring.GetMonitoredResourceDescriptorRequest,
 ) (*monitoredres.MonitoredResourceDescriptor, error) {
-	if err := validation.ValidRequiredFields(req); err != nil {
+	if err := validation.ValidateRequiredFields(req); err != nil {
 		return nil, err
 	}
 	return &monitoredres.MonitoredResourceDescriptor{}, nil
@@ -54,7 +60,7 @@ func (s *MockMetricServer) GetMonitoredResourceDescriptor(ctx context.Context, r
 // that are picked up by the given query.
 func (s *MockMetricServer) ListMonitoredResourceDescriptors(ctx context.Context, req *monitoring.ListMonitoredResourceDescriptorsRequest,
 ) (*monitoring.ListMonitoredResourceDescriptorsResponse, error) {
-	if err := validation.ValidRequiredFields(req); err != nil {
+	if err := validation.ValidateRequiredFields(req); err != nil {
 		return nil, err
 	}
 	return &monitoring.ListMonitoredResourceDescriptorsResponse{
@@ -67,7 +73,7 @@ func (s *MockMetricServer) ListMonitoredResourceDescriptors(ctx context.Context,
 // If it doesn't esxist, an error is returned.
 func (s *MockMetricServer) GetMetricDescriptor(ctx context.Context, req *monitoring.GetMetricDescriptorRequest,
 ) (*metric.MetricDescriptor, error) {
-	if err := validation.ValidRequiredFields(req); err != nil {
+	if err := validation.ValidateRequiredFields(req); err != nil {
 		return nil, err
 	}
 
@@ -85,7 +91,7 @@ func (s *MockMetricServer) GetMetricDescriptor(ctx context.Context, req *monitor
 // If it already exists, an error is returned.
 func (s *MockMetricServer) CreateMetricDescriptor(ctx context.Context, req *monitoring.CreateMetricDescriptorRequest,
 ) (*metric.MetricDescriptor, error) {
-	if err := validation.ValidRequiredFields(req); err != nil {
+	if err := validation.ValidateRequiredFields(req); err != nil {
 		return nil, err
 	}
 	s.uploadedMetricDescriptorsLock.Lock()
@@ -101,7 +107,7 @@ func (s *MockMetricServer) CreateMetricDescriptor(ctx context.Context, req *moni
 // If it doesn't exist, an error is returned.
 func (s *MockMetricServer) DeleteMetricDescriptor(ctx context.Context, req *monitoring.DeleteMetricDescriptorRequest,
 ) (*empty.Empty, error) {
-	if err := validation.ValidRequiredFields(req); err != nil {
+	if err := validation.ValidateRequiredFields(req); err != nil {
 		return nil, err
 	}
 
@@ -117,7 +123,7 @@ func (s *MockMetricServer) DeleteMetricDescriptor(ctx context.Context, req *moni
 // ListMetricDescriptors lists all the metric descriptors that are picked up by the given query.
 func (s *MockMetricServer) ListMetricDescriptors(ctx context.Context, req *monitoring.ListMetricDescriptorsRequest,
 ) (*monitoring.ListMetricDescriptorsResponse, error) {
-	if err := validation.ValidRequiredFields(req); err != nil {
+	if err := validation.ValidateRequiredFields(req); err != nil {
 		return nil, err
 	}
 	return &monitoring.ListMetricDescriptorsResponse{
@@ -130,22 +136,31 @@ func (s *MockMetricServer) ListMetricDescriptors(ctx context.Context, req *monit
 // If it already exists, an error is returned.
 func (s *MockMetricServer) CreateTimeSeries(ctx context.Context, req *monitoring.CreateTimeSeriesRequest,
 ) (*empty.Empty, error) {
-	if err := validation.ValidRequiredFields(req); err != nil {
+	s.uploadedPointsLock.Lock()
+	if err := validation.ValidateRateLimit(req.TimeSeries, s.uploadedPoints); err != nil {
+		s.uploadedPointsLock.Unlock()
+		return nil, err
+	}
+	s.uploadedPointsLock.Unlock()
+	if err := validation.ValidateRequiredFields(req); err != nil {
 		return nil, err
 	}
 	if err := validation.ValidateProjectName(req.Name); err != nil {
 		return nil, err
 	}
-	if err := validation.ValidateCreateTimeSeries(req.TimeSeries, s.uploadedMetricDescriptors); err != nil {
+	if err := validation.ValidateCreateTimeSeries(req.TimeSeries, s.uploadedMetricDescriptors, s.uploadedPoints); err != nil {
 		return nil, err
 	}
+	s.uploadedPointsLock.Lock()
+	defer s.uploadedPointsLock.Unlock()
+	validation.AddPoint(req.TimeSeries, s.uploadedPoints)
 	return &empty.Empty{}, nil
 }
 
 // ListTimeSeries lists all time series that are picked up by the given query.
 func (s *MockMetricServer) ListTimeSeries(ctx context.Context, req *monitoring.ListTimeSeriesRequest,
 ) (*monitoring.ListTimeSeriesResponse, error) {
-	if err := validation.ValidRequiredFields(req); err != nil {
+	if err := validation.ValidateRequiredFields(req); err != nil {
 		return nil, err
 	}
 	return &monitoring.ListTimeSeriesResponse{

--- a/server/metric/mock_metric_test.go
+++ b/server/metric/mock_metric_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/ptypes"
-
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/googleinterns/cloud-operations-api-mock/internal/validation"
 


### PR DESCRIPTION
Finishing up the validation for `CreateTimeSeries` (continuing from [this PR](https://github.com/googleinterns/cloud-operations-api-mock/pull/43)). Specifically, this PR implements the validations that rely on comparison with previous points (see [here](https://docs.google.com/document/d/1eeGeSYlE2F-Dc-5_yLXnIlj7e--BYFeWlzWy6qBV2cg/edit#heading=h.nhu541bsafyk) and [here](https://cloud.google.com/monitoring/quotas#custom_metrics_quotas) for the specific documentation).

To do this, this PR uses a map that maps `{TimeSeries: last point received for that time series}`. Time series are unique based on a unique combination of metric type, metric labels, monitored resource type and monitored resource labels. Since Go doesn't allow structs as keys of maps, we will have to serialize these fields into one long string to use as the map's key. The validations this PR adds are the following: 

- A rate limit of at most one point every 10 seconds for a given TimeSeries
- If the metric type is `CUMULATIVE`, following points must have the same start time and increasing end times
- If the metric type is `GAUGE`, the point must have the same start and end times
- Time series must be unique based on a unique combination of metric type and labels, and monitored resource and labels
